### PR TITLE
Added empty() function to check if a signal has any subscribers

### DIFF
--- a/nano_observer.hpp
+++ b/nano_observer.hpp
@@ -51,6 +51,13 @@ class Observer
 
     //--------------------------------------------------------------------------
 
+    bool empty()
+    {
+        return head == nullptr;
+    }
+
+    //--------------------------------------------------------------------------
+
     template <typename Delegate, typename... Uref>
     void onEach(Uref&&... args)
     {
@@ -87,9 +94,9 @@ class Observer
             {
                 // Remove this slot from this listening Observer
                 node->data.observer->remove(node->data.delegate);
-            }  
+            }
             node = node->next;
-            delete temp;       
+            delete temp;
         }
     }
 

--- a/nano_signal_slot.hpp
+++ b/nano_signal_slot.hpp
@@ -153,6 +153,12 @@ class Signal<RT(Args...)> : private Observer
             (std::forward<Accumulate>(accumulate), std::forward<Uref>(args)...);
     }
 
+    //---------------------------------------------------------------------EMPTY
+
+    bool empty() {
+        return Observer::empty();
+    }
+
 };
 
 } // namespace Nano ------------------------------------------------------------


### PR DESCRIPTION
As per the title.

I have a couple of functions which pass data to the subscriber that is expensive to generate (e.g. parse network related messages, etc.). An `empty` function is useful to conditionally omit generating the data:

    if (!signal.empty()) {
        // do expensive work
        signal.emit(args...);
    }
