### PR TITLE
Fix a missed replacement of operator() to emit

### DIFF
--- a/nano_function.hpp
+++ b/nano_function.hpp
@@ -51,7 +51,7 @@ public:
     static inline Function bind(L* pointer)
     {
         return { pointer, [](void *this_ptr, Args... args)
-            { return (static_cast<L*>(this_ptr)->operator()(std::forward<Args>(args)...)); }};
+            { return (static_cast<L*>(this_ptr)->emit(std::forward<Args>(args)...)); }};
     }
     inline operator DelegateKey() const
     {


### PR DESCRIPTION
When replacing operator() with emit() you seemed to have skipped this place.