### PR TITLE
nano-signal-slot 2.0 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2012-2018 ApEk, NoAvailableAlias, Nano-signal-slot Contributors
+Copyright (c) 2012-2019 ApEk, NoAvailableAlias, Nano-signal-slot Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -117,11 +117,9 @@ Nano-signal-slot has the following threading policies available for use:
 |:-------|:---------:|:---------:|:--------------:|:--------------:|
 | Single threading only | X | - | X | - |
 | Thread safe using mutex | - | X | - | X |
-| Reentrant safe* | - | - | X | ! |
+| Reentrant safe* | - | - | X | X |
 
-_* Reentrant safety achieved using emission list copying and connection lifetime tracking._
-<br />
-_! There is an [open issue](https://github.com/NoAvailableAlias/nano-signal-slot/issues/22) concerning a potential data race in emission when using this policy._
+_* Reentrant safety achieved using emission list copying and reference counting._
 
 #### Threading Policies - Continued
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ signal_one.disconnect(fo);
 
 ## Deadlock Disclaimer
 
-The Nano::TS_Policy available in nano-signal-slot is not reentrant safe and **does not support** recursive Signal operations.
+The Nano::TS_Policy available in nano-signal-slot is not reentrant safe and **could deadlock** for recursive Signal operations.
 However, the Nano::TS_Policy_Strict policy allows for recursive Signal operations at the expense of a performance impact.
 The [issue](https://github.com/NoAvailableAlias/nano-signal-slot/issues/22) will remain open until the next release.
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Pure C++17 Signals and Slots
 
 #### Include
 ```
-// #include "nano_function.hpp"         // Nano::Function<>, Nano::Delegate_Key
+// #include "nano_function.hpp"         // Nano::Function, Nano::Delegate_Key
 // #include "nano_mutex.hpp"            // Nano::Spin_Mutex, Nano::Spin_Mutex_Recursive, all policies
-// #include "nano_observer.hpp"         // Nano::Observer<>
-#include "nano_signal_slot.hpp"         // Nano::Signal<>
+// #include "nano_observer.hpp"         // Nano::Observer
+#include "nano_signal_slot.hpp"         // Nano::Signal
 ```
 
 #### Declare
@@ -125,7 +125,7 @@ _* Reentrant safety achieved using emission list copying and reference counting.
 
 When integrating nano-signal-slot, it is recommended to alias the Nano::Signal and Nano::Observer template classes.
 <br />
-**When using a non-default Policy you must make sure that both Nano::Signal and Observer use the same policy.**
+**When using a non-default Policy you must make sure that both Signal and Observer use the same policy.**
 
 ```
 namespace Your_Namespace
@@ -139,6 +139,13 @@ using Your_Observer = Nano::Observer<Nano::TS_Policy_Safe<>>;
 
 }
 ```
+
+## Deadlock Disclaimer
+
+The TS_Policy does not mitigate any deadlocks that could occur due to slot emissions fiddling with their signals.
+Additionally, when using this policy, it is not safe to destruct connected Nano::Observers from different threads.
+Generally if the threading posture in your application allows for it then use the TS_Policy for the performance.
+If the lifetimes of Signals vs Observers is unknown or if the slots could be hostile then use the TS_Policy_Safe.
 
 #### Links
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ signal_one.disconnect(fo);
 
 ## Deadlock Disclaimer
 
-Currently nano-signal-slot is not reentrant safe and **does not support** any recursive Signal operations from within Slot emission.
-Doing so could cause a deadlock scenario if these operations are performed across threads.
-The [issue](https://github.com/NoAvailableAlias/nano-signal-slot/issues/22) will remain open until a suitable rework is ready.
+The Nano::TS_Policy available in nano-signal-slot is not reentrant safe and **does not support** recursive Signal operations.
+However, the Nano::TS_Policy_Strict policy allows for recursive Signal operations at the expense of a performance impact.
+The [issue](https://github.com/NoAvailableAlias/nano-signal-slot/issues/22) will remain open until the next release.
 
 #### Links
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pure C++17 Signals and Slots
 #### Include
 ```
 // #include "nano_function.hpp"         // Nano::Function, Nano::Delegate_Key
-// #include "nano_mutex.hpp"            // Nano::Spin_Mutex, Nano::Spin_Mutex_Recursive, all policies
+// #include "nano_mutex.hpp"            // Nano::Spin_Mutex, all threading policies
 // #include "nano_observer.hpp"         // Nano::Observer
 #include "nano_signal_slot.hpp"         // Nano::Signal
 ```

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Pure C++17 Signals and Slots
 
 #### Include
 ```
-// #include "nano_function.hpp"         // Nano::Function, Nano::Delegate_Key
-// #include "nano_mutex.hpp"            // Nano::Noop_Mutex, Nano::Recursive_Mutex
-// #include "nano_observer.hpp"         // Nano::Observer
-#include "nano_signal_slot.hpp"         // Nano::Signal
+// #include "nano_function.hpp"         // Nano::Function<>, Nano::Delegate_Key
+// #include "nano_mutex.hpp"            // Nano::Spin_Mutex, Nano::Spin_Mutex_Recursive, all policies
+// #include "nano_observer.hpp"         // Nano::Observer<>
+#include "nano_signal_slot.hpp"         // Nano::Signal<>
 ```
 
 #### Declare
@@ -109,11 +109,20 @@ signal_one.connect(fo);
 signal_one.disconnect(fo);
 ```
 
-## Deadlock Disclaimer
+#### Policies
 
-The Nano::TS_Policy available in nano-signal-slot is not reentrant safe and **could deadlock** for recursive Signal operations.
-However, the Nano::TS_Policy_Strict policy allows for recursive Signal operations at the expense of a performance impact.
-The [issue](https://github.com/NoAvailableAlias/nano-signal-slot/issues/22) will remain open until the next release.
+Nano-signal-slot has 4 threading policies available for use:
+
+| &nbsp; | ST_Policy | TS_Policy | ST_Policy_Safe | TS_Policy_Safe |
+|:------:|:---------:|:---------:|:--------------:|:--------------:|
+| Single threading only | X | - | X | - |
+| Thread safe using mutex | - | X | - | X |
+| Reentrant safe* | - | - | X | ! |
+
+_*Reentrant safety achieved using emission list copying and connection lifetime tracking._
+_!There is an open issue concerning a potential data race in emission when using this policy._
+<br />
+**When using a non-default Policy you must make sure that both Nano::Signal and Observer use the same policy.**
 
 #### Links
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ signal_one.disconnect(fo);
 
 #### Threading Policies
 
-Nano-signal-slot has 4 threading policies available for use:
+Nano-signal-slot has the following threading policies available for use:
 
 | &nbsp; | ST_Policy | TS_Policy | ST_Policy_Safe | TS_Policy_Safe |
 |:-------|:---------:|:---------:|:--------------:|:--------------:|
@@ -136,8 +136,8 @@ namespace Your_Namespace
 // Creating aliases when using nano-signal-slot will increase the maintainability of your code
 // especially if you are choosing to use the alternative policies.
 template <typename Signatue>
-using Your_Signal<Signature> = Nano::Signal<Signature, Nano::TS_Policy_Safe>;
-using Your_Observer = Nano::Observer<Nano::TS_Policy_Safe>;
+using Your_Signal<Signature> = Nano::Signal<Signature, Nano::TS_Policy_Safe<>>;
+using Your_Observer = Nano::Observer<Nano::TS_Policy_Safe<>>;
 
 }
 ```

--- a/README.md
+++ b/README.md
@@ -109,24 +109,40 @@ signal_one.connect(fo);
 signal_one.disconnect(fo);
 ```
 
-#### Policies
+#### Threading Policies
 
 Nano-signal-slot has 4 threading policies available for use:
 
 | &nbsp; | ST_Policy | TS_Policy | ST_Policy_Safe | TS_Policy_Safe |
-|:------:|:---------:|:---------:|:--------------:|:--------------:|
+|:-------|:---------:|:---------:|:--------------:|:--------------:|
 | Single threading only | X | - | X | - |
 | Thread safe using mutex | - | X | - | X |
 | Reentrant safe* | - | - | X | ! |
 
-_*Reentrant safety achieved using emission list copying and connection lifetime tracking._
-_!There is an open issue concerning a potential data race in emission when using this policy._
+_* Reentrant safety achieved using emission list copying and connection lifetime tracking._
+<br />
+_! There is an [open issue](https://github.com/NoAvailableAlias/nano-signal-slot/issues/22) concerning a potential data race in emission when using this policy._
+
+#### Threading Policies - Continued
+
+When integrating nano-signal-slot, it is recommended to alias the Nano::Signal and Nano::Observer template classes.
 <br />
 **When using a non-default Policy you must make sure that both Nano::Signal and Observer use the same policy.**
 
-#### Links
+```
+namespace Your_Namespace
+{
 
-*_Benchmarks contain both the old nano-signal-slot v1.x scores as well as the v2.x scores._
+// Creating aliases when using nano-signal-slot will increase the maintainability of your code
+// especially if you are choosing to use the alternative policies.
+template <typename Signatue>
+using Your_Signal<Signature> = Nano::Signal<Signature, Nano::TS_Policy_Safe>;
+using Your_Observer = Nano::Observer<Nano::TS_Policy_Safe>;
+
+}
+```
+
+#### Links
 
 | [Benchmark Results](https://github.com/NoAvailableAlias/signal-slot-benchmarks/tree/master/#signal-slot-benchmarks) | [Benchmark Algorithms](https://github.com/NoAvailableAlias/signal-slot-benchmarks/tree/master/#benchmark-algorithms) | [Unit Tests](https://github.com/NoAvailableAlias/nano-signal-slot/tree/master/tests/#unit-tests) |
 |:-------------------------------------------------------------------------------------------------------------------:|:--------------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------:|

--- a/nano_function.hpp
+++ b/nano_function.hpp
@@ -6,13 +6,13 @@
 namespace Nano
 {
 
-using Delegate_Key = std::array<const std::uintptr_t, 2>;
+using Delegate_Key = std::array<std::uintptr_t, 2>;
 
 template <typename RT> class Function;
 template <typename RT, typename... Args>
 class Function<RT(Args...)> final
 {
-    // Only Nano::Observer is allowed access
+    // Only Nano::Observer is allowed private access
     template <typename> friend class Observer;
 
     using Thunk = RT(*)(void*, Args&&...);
@@ -28,7 +28,7 @@ class Function<RT(Args...)> final
 
     public:
 
-    void* instance_pointer;
+    void* const instance_pointer;
     const Thunk function_pointer;
 
     template <auto fun_ptr>

--- a/nano_function.hpp
+++ b/nano_function.hpp
@@ -67,10 +67,9 @@ class Function<RT(Args...)> final
         };
     }
 
-    template <typename... Uref>
-    inline RT operator() (Uref&&... args)
+    inline RT operator() (Args... args)
     {
-        return (*function_pointer)(instance_pointer, std::forward<Uref>(args)...);
+        return (*function_pointer)(instance_pointer, std::forward<Args>(args)...);
     }
 
     inline operator Delegate_Key() const

--- a/nano_mutex.hpp
+++ b/nano_mutex.hpp
@@ -14,14 +14,9 @@ class Spin_Mutex
 
     public:
 
-    inline bool try_lock()
-    {
-        return !lock_flag.test_and_set(std::memory_order_acquire);
-    }
-
     inline void lock()
     {
-        while (!try_lock())
+        while (lock_flag.test_and_set(std::memory_order_acquire))
         {
             std::this_thread::yield();
         }
@@ -30,51 +25,6 @@ class Spin_Mutex
     inline void unlock()
     {
         lock_flag.clear(std::memory_order_release);
-    }
-};
-
-//------------------------------------------------------------------------------
-
-class Spin_Mutex_Recursive
-{
-    std::atomic<std::thread::id> owner_thread_id = std::thread::id();
-    std::uint64_t recursive_counter = 0;
-    std::atomic_flag lock_flag = ATOMIC_FLAG_INIT;
-
-    public:
-
-    inline bool try_lock()
-    {
-        if (!lock_flag.test_and_set(std::memory_order_acquire))
-        {
-            owner_thread_id.store(std::this_thread::get_id(), std::memory_order_release);
-        }
-        else if (owner_thread_id.load(std::memory_order_acquire) != std::this_thread::get_id())
-        {
-            return false;
-        }
-        ++recursive_counter;
-        return true;
-    }
-
-    inline void lock()
-    {
-        while (!try_lock())
-        {
-            std::this_thread::yield();
-        }
-    }
-
-    inline void unlock()
-    {
-        assert(owner_thread_id.load(std::memory_order_acquire) == std::this_thread::get_id());
-        assert(recursive_counter > 0);
-
-        if (--recursive_counter == 0)
-        {
-            owner_thread_id.store(std::thread::id(), std::memory_order_release);
-            lock_flag.clear(std::memory_order_release);
-        }
     }
 };
 

--- a/nano_mutex.hpp
+++ b/nano_mutex.hpp
@@ -180,7 +180,7 @@ class ST_Policy_Strict
     }
 };
 
-template <typename Mutex = Recursive_Spin_Mutex>
+template <typename Mutex = Spin_Mutex>
 class TS_Policy_Strict
 {
     using Lock_Guard = std::unique_lock<TS_Policy_Strict>;

--- a/nano_mutex.hpp
+++ b/nano_mutex.hpp
@@ -14,12 +14,12 @@ class Spin_Mutex
 
     public:
 
-    bool try_lock()
+    inline bool try_lock()
     {
         return !lock_flag.test_and_set(std::memory_order_acquire);
     }
 
-    void lock()
+    inline void lock()
     {
         while (!try_lock())
         {
@@ -27,7 +27,7 @@ class Spin_Mutex
         }
     }
 
-    void unlock()
+    inline void unlock()
     {
         lock_flag.clear(std::memory_order_release);
     }

--- a/nano_mutex.hpp
+++ b/nano_mutex.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cassert>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -15,7 +14,7 @@ class Spin_Mutex
 
     public:
 
-    inline void lock()
+    inline void lock() noexcept
     {
         while (lock_flag.test_and_set(std::memory_order_acquire))
         {
@@ -23,10 +22,14 @@ class Spin_Mutex
         }
     }
 
-    inline void unlock()
+    inline void unlock() noexcept
     {
         lock_flag.clear(std::memory_order_release);
     }
+
+    Spin_Mutex() = default;
+    Spin_Mutex(Spin_Mutex const&) = delete;
+    Spin_Mutex& operator= (Spin_Mutex const&) = delete;
 };
 
 //------------------------------------------------------------------------------
@@ -68,7 +71,7 @@ class ST_Policy
     template <typename T>
     constexpr auto static_pointer_cast(Weak_Ptr observer) const
     {
-        return (T*)observer;
+        return static_cast<T*>(observer);
     }
 
     constexpr void before_disconnect_all() const
@@ -129,7 +132,7 @@ class TS_Policy
     template <typename T>
     constexpr auto static_pointer_cast(Weak_Ptr observer) const
     {
-        return (T*)observer;
+        return static_cast<T*>(observer);
     }
 
     constexpr void before_disconnect_all() const
@@ -177,7 +180,7 @@ class ST_Policy_Safe
     template <typename T>
     constexpr auto static_pointer_cast(Weak_Ptr observer) const
     {
-        return (T*)observer;
+        return static_cast<T*>(observer);
     }
 
     constexpr void before_disconnect_all() const
@@ -244,7 +247,7 @@ class TS_Policy_Safe
     template <typename T>
     inline auto static_pointer_cast(Shared_Ptr& observer)
     {
-        return std::static_pointer_cast<T>(observer);
+        return static_cast<T*>(observer.get());
     }
 
     inline void before_disconnect_all()

--- a/nano_mutex.hpp
+++ b/nano_mutex.hpp
@@ -1,57 +1,55 @@
 #pragma once
 
-#include <atomic>
-#include <thread>
 #include <cassert>
+#include <atomic>
+#include <mutex>
+#include <thread>
 
 namespace Nano
 {
 
-// When using a sane optimization level,
-// the use of this class with std::shared_lock
-// or std::unique_lock will be completely optimized away.
-
-class Noop_Mutex
+class Spin_Mutex
 {
+    std::atomic<std::thread::id> owner_thread_id = std::thread::id();
+    std::atomic_flag lock_flag = ATOMIC_FLAG_INIT;
+
     public:
 
-    constexpr bool lock() const
+    bool try_lock()
     {
+        if (!lock_flag.test_and_set(std::memory_order_acquire))
+        {
+            owner_thread_id.store(std::this_thread::get_id(), std::memory_order_release);
+        }
+        else if (owner_thread_id.load(std::memory_order_acquire) != std::this_thread::get_id())
+        {
+            return false;
+        }
         return true;
     }
 
-    constexpr bool try_lock() const
+    void lock()
     {
-        return true;
+        while (!try_lock())
+        {
+            std::this_thread::yield();
+        }
     }
 
-    constexpr void unlock() noexcept
+    void unlock()
     {
-
-    }
-
-    constexpr void lock_shared()
-    {
-
-    }
-
-    constexpr bool try_lock_shared() const
-    {
-        return true;
-    }
-
-    constexpr void unlock_shared()
-    {
-
+        assert(owner_thread_id.load(std::memory_order_acquire) == std::this_thread::get_id());
+        owner_thread_id.store(std::thread::id(), std::memory_order_release);
+        lock_flag.clear(std::memory_order_release);
     }
 };
 
 //------------------------------------------------------------------------------
 
-class Recursive_Mutex
+class Recursive_Spin_Mutex
 {
     std::atomic<std::thread::id> owner_thread_id = std::thread::id();
-    std::uint32_t recursive_counter = 0;
+    std::uint64_t recursive_counter = 0;
     std::atomic_flag lock_flag = ATOMIC_FLAG_INIT;
 
     public:
@@ -88,6 +86,140 @@ class Recursive_Mutex
             owner_thread_id.store(std::thread::id(), std::memory_order_release);
             lock_flag.clear(std::memory_order_release);
         }
+    }
+};
+
+//------------------------------------------------------------------------------
+
+class ST_Policy
+{
+    public:
+
+    template <typename T>
+    static inline T const& copy_or_ref(T const& param)
+    {
+        return param;
+    }
+
+    constexpr void lock() const
+    {
+
+    }
+
+    constexpr bool try_lock() const
+    {
+        return true;
+    }
+
+    constexpr void unlock() noexcept
+    {
+
+    }
+
+    constexpr bool get_lock_guard() const
+    {
+        return false;
+    }
+};
+
+template <typename Mutex = Spin_Mutex>
+class TS_Policy
+{
+    mutable Mutex m_mutex;
+
+    public:
+
+    template <typename T>
+    static inline T const& copy_or_ref(T const& param)
+    {
+        return param;
+    }
+
+    inline void lock() const
+    {
+        m_mutex.lock();
+    }
+
+    inline bool try_lock() const
+    {
+        return m_mutex.try_lock();
+    }
+
+    inline void unlock() noexcept
+    {
+        m_mutex.unlock();
+    }
+
+    inline std::lock_guard<TS_Policy> get_lock_guard() const
+    {
+        return std::lock_guard<TS_Policy>(*const_cast<TS_Policy*>(this));
+    }
+};
+
+//------------------------------------------------------------------------------
+
+class ST_Policy_Strict
+{
+    public:
+
+    template <typename T>
+    static inline T const& copy_or_ref(T const& param)
+    {
+        return param;
+    }
+
+    constexpr void lock() const
+    {
+
+    }
+
+    constexpr bool try_lock() const
+    {
+        return true;
+    }
+
+    constexpr void unlock() noexcept
+    {
+
+    }
+
+    constexpr bool get_lock_guard() const
+    {
+        return false;
+    }
+};
+
+template <typename Mutex = Recursive_Spin_Mutex>
+class TS_Policy_Strict
+{
+    mutable Mutex m_mutex;
+
+    public:
+
+    template <typename T>
+    static inline T const& copy_or_ref(T const& param)
+    {
+        return param;
+    }
+
+    inline void lock() const
+    {
+        m_mutex.lock();
+    }
+
+    inline bool try_lock() const
+    {
+        return m_mutex.try_lock();
+    }
+
+    inline void unlock() noexcept
+    {
+        m_mutex.unlock();
+    }
+
+    inline std::lock_guard<TS_Policy_Strict> get_lock_guard() const
+    {
+        return std::lock_guard<TS_Policy_Strict>(*const_cast<TS_Policy_Strict*>(this));
     }
 };
 

--- a/nano_mutex.hpp
+++ b/nano_mutex.hpp
@@ -10,22 +10,13 @@ namespace Nano
 
 class Spin_Mutex
 {
-    std::atomic<std::thread::id> owner_thread_id = std::thread::id();
     std::atomic_flag lock_flag = ATOMIC_FLAG_INIT;
 
     public:
 
     bool try_lock()
     {
-        if (!lock_flag.test_and_set(std::memory_order_acquire))
-        {
-            owner_thread_id.store(std::this_thread::get_id(), std::memory_order_release);
-        }
-        else if (owner_thread_id.load(std::memory_order_acquire) != std::this_thread::get_id())
-        {
-            return false;
-        }
-        return true;
+        return !lock_flag.test_and_set(std::memory_order_acquire);
     }
 
     void lock()
@@ -38,8 +29,6 @@ class Spin_Mutex
 
     void unlock()
     {
-        assert(owner_thread_id.load(std::memory_order_acquire) == std::this_thread::get_id());
-        owner_thread_id.store(std::thread::id(), std::memory_order_release);
         lock_flag.clear(std::memory_order_release);
     }
 };

--- a/nano_mutex.hpp
+++ b/nano_mutex.hpp
@@ -40,7 +40,7 @@ class ST_Policy
         return param;
     }
 
-    constexpr bool get_lock_guard() const
+    constexpr bool lock_guard() const
     {
         return false;
     }
@@ -59,9 +59,7 @@ class ST_Policy
 template <typename Mutex = Spin_Mutex>
 class TS_Policy
 {
-    using Lock_Guard = std::lock_guard<TS_Policy>;
-
-    mutable Mutex m_mutex;
+    mutable Mutex mutex;
 
     public:
 
@@ -71,19 +69,19 @@ class TS_Policy
         return param;
     }
 
-    inline Lock_Guard get_lock_guard() const
+    inline std::lock_guard<TS_Policy> lock_guard() const
     {
-        return Lock_Guard(*const_cast<TS_Policy*>(this));
+        return std::lock_guard<TS_Policy>(*const_cast<TS_Policy*>(this));
     }
 
     inline void lock() const
     {
-        m_mutex.lock();
+        mutex.lock();
     }
 
     inline void unlock() noexcept
     {
-        m_mutex.unlock();
+        mutex.unlock();
     }
 };
 
@@ -99,7 +97,7 @@ class ST_Policy_Safe
         return param;
     }
 
-    constexpr bool get_lock_guard() const
+    constexpr bool lock_guard() const
     {
         return false;
     }
@@ -118,32 +116,30 @@ class ST_Policy_Safe
 template <typename Mutex = Spin_Mutex>
 class TS_Policy_Safe
 {
-    using Lock_Guard = std::unique_lock<TS_Policy_Safe>;
-
-    mutable Mutex m_mutex;
+    mutable Mutex mutex;
 
     public:
 
     template <typename T, typename L>
     inline T copy_or_ref(T const& param, L&& lock) const
     {
-        Lock_Guard unlock_after_copy = std::move(lock);
+        std::unique_lock<TS_Policy_Safe> unlock_after_copy = std::move(lock);
         return param;
     }
 
-    inline Lock_Guard get_lock_guard() const
+    inline std::unique_lock<TS_Policy_Safe> lock_guard() const
     {
-        return Lock_Guard(*const_cast<TS_Policy_Safe*>(this));
+        return std::unique_lock<TS_Policy_Safe>(*const_cast<TS_Policy_Safe*>(this));
     }
 
     inline void lock() const
     {
-        m_mutex.lock();
+        mutex.lock();
     }
 
     inline void unlock() noexcept
     {
-        m_mutex.unlock();
+        mutex.unlock();
     }
 };
 

--- a/nano_observer.hpp
+++ b/nano_observer.hpp
@@ -42,7 +42,7 @@ class Observer : private MT_Policy
 
         inline bool operator()(Connection const& lhs, Connection const& rhs) const
         {
-            return this->operator()(lhs.delegate, rhs.delegate);
+            return operator()(lhs.delegate, rhs.delegate);
         }
     };
 

--- a/nano_observer.hpp
+++ b/nano_observer.hpp
@@ -135,10 +135,7 @@ class Observer : private MT_Policy
     {
         auto lock = MT_Policy::get_lock_guard();
 
-        return std::all_of(connections.cbegin(), connections.cend(), [](auto const& slot)
-        {
-            return slot.observer == nullptr;
-        });
+        return connections.empty() || connections.back().observer == nullptr;
     }
 
     protected:

--- a/nano_observer.hpp
+++ b/nano_observer.hpp
@@ -58,10 +58,12 @@ class Observer : private MT_Policy
 
         if (start == stop || start->observer)
         {
+            // No empty slot can be reused so binary emplace to the correct index
             connections.emplace(std::upper_bound(start, stop, key, Z_Order()), key, observer);
         }
         else
         {
+            // Reuse an empty slot and optimize sort to the correct order
             connections[0] = { key, observer };
             std::sort(start, std::lower_bound(start, stop, key, Z_Order()), Z_Order());
         }
@@ -78,6 +80,7 @@ class Observer : private MT_Policy
 
         if (slot != stop)
         {
+            // Rotate slot to the front and zero out the slot
             std::rotate(start, slot, slot + 1);
             connections[0] = {};
         }

--- a/nano_observer.hpp
+++ b/nano_observer.hpp
@@ -31,12 +31,8 @@ class Observer : private MT_Policy
         {
             std::size_t x = lhs[0] ^ rhs[0];
             std::size_t y = lhs[1] ^ rhs[1];
-
-            if ((x < y) && (x < (x ^ y)))
-            {
-                return lhs[1] < rhs[1];
-            }
-            return lhs[0] < rhs[0];
+            auto k = (x < y) && x < (x ^ y);
+            return lhs[k] < rhs[k];
         }
 
         inline bool operator()(Connection const& lhs, Connection const& rhs) const
@@ -51,7 +47,7 @@ class Observer : private MT_Policy
 
     void insert(Delegate_Key const& key, Observer* observer)
     {
-        auto lock = MT_Policy::get_lock_guard();
+        auto lock = MT_Policy::lock_guard();
 
         auto begin = std::begin(connections);
         auto end = std::end(connections);
@@ -61,7 +57,7 @@ class Observer : private MT_Policy
 
     void remove(Delegate_Key const& key) noexcept
     {
-        auto lock = MT_Policy::get_lock_guard();
+        auto lock = MT_Policy::lock_guard();
 
         auto begin = std::begin(connections);
         auto end = std::end(connections);
@@ -75,7 +71,7 @@ class Observer : private MT_Policy
     template <typename Function, typename... Uref>
     void for_each(Uref&&... args)
     {
-        auto lock = MT_Policy::get_lock_guard();
+        auto lock = MT_Policy::lock_guard();
 
         for (auto const& slot : MT_Policy::copy_or_ref(connections, lock))
         {
@@ -86,7 +82,7 @@ class Observer : private MT_Policy
     template <typename Function, typename Accumulate, typename... Uref>
     void for_each_accumulate(Accumulate&& accumulate, Uref&&... args)
     {
-        auto lock = MT_Policy::get_lock_guard();
+        auto lock = MT_Policy::lock_guard();
 
         for (auto const& slot : MT_Policy::copy_or_ref(connections, lock))
         {
@@ -100,7 +96,7 @@ class Observer : private MT_Policy
 
     void disconnect_all() noexcept
     {
-        auto lock = MT_Policy::get_lock_guard();
+        auto lock = MT_Policy::lock_guard();
 
         for (auto const& slot : connections)
         {
@@ -114,7 +110,7 @@ class Observer : private MT_Policy
 
     bool is_empty() const noexcept
     {
-        auto lock = MT_Policy::get_lock_guard();
+        auto lock = MT_Policy::lock_guard();
 
         return connections.empty();
     }
@@ -127,6 +123,10 @@ class Observer : private MT_Policy
     {
         disconnect_all();
     }
+
+    Observer() = default;
+    Observer(Observer const&) = delete;
+    Observer& operator= (Observer const&) = delete;
 };
 
 } // namespace Nano ------------------------------------------------------------

--- a/nano_observer.hpp
+++ b/nano_observer.hpp
@@ -45,14 +45,14 @@ class Observer : private MT_Policy
 
     //--------------------------------------------------------------------------
 
-    void insert(Delegate_Key const& key, Observer* observer)
+    void insert(Delegate_Key const& key, Observer* obs)
     {
         auto lock = MT_Policy::lock_guard();
 
         auto begin = std::begin(connections);
         auto end = std::end(connections);
 
-        connections.emplace(std::upper_bound(begin, end, key, Z_Order()), key, observer);
+        connections.emplace(std::upper_bound(begin, end, key, Z_Order()), key, obs);
     }
 
     void remove(Delegate_Key const& key) noexcept

--- a/nano_observer.hpp
+++ b/nano_observer.hpp
@@ -86,7 +86,7 @@ class Observer : private MT_Policy
     //--------------------------------------------------------------------------
 
     template <typename Function, typename... Uref>
-    void for_each(Uref&&... args) const
+    void for_each(Uref&&... args)
     {
         auto lock = MT_Policy::get_lock_guard();
 
@@ -100,7 +100,7 @@ class Observer : private MT_Policy
     }
 
     template <typename Function, typename Accumulate, typename... Uref>
-    void for_each_accumulate(Accumulate&& accumulate, Uref&&... args) const
+    void for_each_accumulate(Accumulate&& accumulate, Uref&&... args)
     {
         auto lock = MT_Policy::get_lock_guard();
 

--- a/nano_observer.hpp
+++ b/nano_observer.hpp
@@ -21,7 +21,7 @@ class Observer : private MT_Policy
         typename MT_Policy::Weak_Ptr observer;
 
         Connection() noexcept = default;
-        Connection(Delegate_Key const& key) : delegate(key) {}
+        Connection(Delegate_Key const& key) : delegate(key), observer() {}
         Connection(Delegate_Key const& key, Observer* obs) : delegate(key), observer(obs->weak_ptr()) {}
     };
 

--- a/nano_signal_slot.hpp
+++ b/nano_signal_slot.hpp
@@ -11,30 +11,30 @@ class Signal;
 template <typename RT, typename MT_Policy, typename... Args>
 class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
 {
-    using Observer = Observer<MT_Policy>;
-    using Function = Function<RT(Args...)>;
+    using observer = Observer<MT_Policy>;
+    using function = Function<RT(Args...)>;
 
     template <typename T>
     void insert_sfinae(Delegate_Key const& key, typename T::Observer* instance)
     {
-        Observer::insert(key, instance);
+        observer::insert(key, instance);
         instance->insert(key, this);
     }
     template <typename T>
     void remove_sfinae(Delegate_Key const& key, typename T::Observer* instance)
     {
-        Observer::remove(key);
+        observer::remove(key);
         instance->remove(key);
     }
     template <typename T>
     void insert_sfinae(Delegate_Key const& key, ...)
     {
-        Observer::insert(key, this);
+        observer::insert(key, this);
     }
     template <typename T>
     void remove_sfinae(Delegate_Key const& key, ...)
     {
-        Observer::remove(key);
+        observer::remove(key);
     }
 
     public:
@@ -44,7 +44,7 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     template <typename L>
     void connect(L* instance)
     {
-        Observer::insert(Function::template bind(instance), this);
+        observer::insert(function::template bind(instance), this);
     }
     template <typename L>
     void connect(L& instance)
@@ -55,18 +55,18 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     template <RT(*fun_ptr)(Args...)>
     void connect()
     {
-        Observer::insert(Function::template bind<fun_ptr>(), this);
+        observer::insert(function::template bind<fun_ptr>(), this);
     }
 
     template <typename T, RT(T::*mem_ptr)(Args...)>
     void connect(T* instance)
     {
-        insert_sfinae<T>(Function::template bind<mem_ptr>(instance), instance);
+        insert_sfinae<T>(function::template bind<mem_ptr>(instance), instance);
     }
     template <typename T, RT(T::*mem_ptr)(Args...) const>
     void connect(T* instance)
     {
-        insert_sfinae<T>(Function::template bind<mem_ptr>(instance), instance);
+        insert_sfinae<T>(function::template bind<mem_ptr>(instance), instance);
     }
 
     template <typename T, RT(T::*mem_ptr)(Args...)>
@@ -83,7 +83,7 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     template <auto mem_ptr, typename T>
     void connect(T* instance)
     {
-        insert_sfinae<T>(Function::template bind<mem_ptr>(instance), instance);
+        insert_sfinae<T>(function::template bind<mem_ptr>(instance), instance);
     }
     template <auto mem_ptr, typename T>
     void connect(T& instance)
@@ -96,7 +96,7 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     template <typename L>
     void disconnect(L* instance)
     {
-        Observer::remove(Function::template bind(instance));
+        observer::remove(function::template bind(instance));
     }
     template <typename L>
     void disconnect(L& instance)
@@ -107,18 +107,18 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     template <RT(*fun_ptr)(Args...)>
     void disconnect()
     {
-        Observer::remove(Function::template bind<fun_ptr>());
+        observer::remove(function::template bind<fun_ptr>());
     }
 
     template <typename T, RT(T::*mem_ptr)(Args...)>
     void disconnect(T* instance)
     {
-        remove_sfinae<T>(Function::template bind<mem_ptr>(instance), instance);
+        remove_sfinae<T>(function::template bind<mem_ptr>(instance), instance);
     }
     template <typename T, RT(T::*mem_ptr)(Args...) const>
     void disconnect(T* instance)
     {
-        remove_sfinae<T>(Function::template bind<mem_ptr>(instance), instance);
+        remove_sfinae<T>(function::template bind<mem_ptr>(instance), instance);
     }
 
     template <typename T, RT(T::*mem_ptr)(Args...)>
@@ -135,7 +135,7 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     template <auto mem_ptr, typename T>
     void disconnect(T* instance)
     {
-        remove_sfinae<T>(Function::template bind<mem_ptr>(instance), instance);
+        remove_sfinae<T>(function::template bind<mem_ptr>(instance), instance);
     }
     template <auto mem_ptr, typename T>
     void disconnect(T& instance)
@@ -148,13 +148,13 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     template <typename... Uref>
     void fire(Uref&&... args)
     {
-        Observer::template for_each<Function>(std::forward<Uref>(args)...);
+        observer::template for_each<function>(std::forward<Uref>(args)...);
     }
 
     template <typename Accumulate, typename... Uref>
     void fire_accumulate(Accumulate&& accumulate, Uref&&... args)
     {
-        Observer::template for_each_accumulate<Function, Accumulate>
+        observer::template for_each_accumulate<function, Accumulate>
             (std::forward<Accumulate>(accumulate), std::forward<Uref>(args)...);
     }
 };

--- a/nano_signal_slot.hpp
+++ b/nano_signal_slot.hpp
@@ -146,13 +146,13 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     //----------------------------------------------------FIRE / FIRE ACCUMULATE
 
     template <typename... Uref>
-    void fire(Uref&&... args) const
+    void fire(Uref&&... args)
     {
         Observer::template for_each<Function>(std::forward<Uref>(args)...);
     }
 
     template <typename Accumulate, typename... Uref>
-    void fire_accumulate(Accumulate&& accumulate, Uref&&... args) const
+    void fire_accumulate(Accumulate&& accumulate, Uref&&... args)
     {
         Observer::template for_each_accumulate<Function, Accumulate>
             (std::forward<Accumulate>(accumulate), std::forward<Uref>(args)...);

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,6 +41,10 @@ Currently nano-signal-slot now uses Visual Studio for all tests.
 | | Test_Overloaded_Virtual_Member_Fire | PASS |
 | | Test_Overloaded_Virtual_Derived_Member_Fire | PASS |
 | | Test_Fire_Accumulate | PASS |
+| Test_ST_Policy | | |
+| | Test_Global_Signal | PASS |
+| Test_ST_Policy_Safe | | |
+| | Test_Global_Signal | PASS |
 | Test_TS_Policy | | |
 | | Test_Shared_Signal | PASS |
 | Test_TS_Policy_Safe | | |

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,5 +40,9 @@ Currently nano-signal-slot now uses Visual Studio for all tests.
 | | Test_Overloaded_Virtual_Member_Fire | PASS |
 | | Test_Overloaded_Virtual_Derived_Member_Fire | PASS |
 | | Test_Fire_Accumulate | PASS |
+| Test_TS_Policy | | |
+| | Test_Shared_Signal | PASS |
+| Test_TS_Policy_Strict | | |
+| | Test_Shared_Signal | PASS |
 
 _**Dashes currently denote unsupported use cases.*_

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,7 +43,7 @@ Currently nano-signal-slot now uses Visual Studio for all tests.
 | | Test_Fire_Accumulate | PASS |
 | Test_TS_Policy | | |
 | | Test_Shared_Signal | PASS |
-| Test_TS_Policy_Strict | | |
+| Test_TS_Policy_Safe | | |
 | | Test_Shared_Signal | PASS |
 
 _**Dashes currently denote unsupported use cases.*_

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,7 @@ Currently nano-signal-slot now uses Visual Studio for all tests.
 | | Test_Fire_Connects | PASS |
 | | Test_Fire_Disconnect_All | PASS |
 | | Test_Fire_Recursive_Fire | &mdash; |
+| | Test_Signal_Copy | &mdash; |
 | Test_Signal_Fire | | |
 | | Test_Member_Fire | PASS |
 | | Test_Const_Member_Fire | PASS |

--- a/tests/Test_Base.hpp
+++ b/tests/Test_Base.hpp
@@ -17,19 +17,23 @@ namespace Nano_Tests
         }
     }
 
-#if defined(NANO_DEFINE_THREADSAFE_SIGNALS) || true
-
-    using Observer = Nano::Observer<Nano::Recursive_Mutex>;
-    using Signal_One = Nano::Signal<void(const char*), Nano::Recursive_Mutex>;
-    using Signal_Two = Nano::Signal<void(const char*, std::size_t), Nano::Recursive_Mutex>;
-
-#else
-
     using Observer = Nano::Observer<>;
     using Signal_One = Nano::Signal<void(const char*)>;
     using Signal_Two = Nano::Signal<void(const char*, std::size_t)>;
 
-#endif
+    // TODO Add Policy related testing
+
+    //using Observer_TS = Nano::Observer<Nano::TS_Policy<>>;
+    //using Signal_One_TS = Nano::Signal<void(const char*), Nano::TS_Policy<>>;
+    //using Signal_Two_TS = Nano::Signal<void(const char*, std::size_t), Nano::TS_Policy<>>;
+
+    using Observer_STS = Nano::Observer<Nano::ST_Policy_Strict>;
+    using Signal_One_STS = Nano::Signal<void(const char*), Nano::ST_Policy_Strict>;
+    using Signal_Two_STS = Nano::Signal<void(const char*, std::size_t), Nano::ST_Policy_Strict>;
+
+    //using Observer_TSS = Nano::Observer<Nano::TS_Policy_Strict<>>;
+    //using Signal_One_TSS = Nano::Signal<void(const char*), Nano::TS_Policy_Strict<>>;
+    //using Signal_Two_TSS = Nano::Signal<void(const char*, std::size_t), Nano::TS_Policy_Strict<>>;
 
     using Delegate_One = std::function<void(const char*)>;
     using Delegate_Two = std::function<void(const char*, std::size_t)>;

--- a/tests/Test_Base.hpp
+++ b/tests/Test_Base.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <mutex>
+#include <iostream>
 #include <functional>
+#include <random>
 
 #include "../nano_signal_slot.hpp"
 #include "../nano_mutex.hpp"
@@ -17,23 +18,17 @@ namespace Nano_Tests
         }
     }
 
+    using Rng = std::minstd_rand;
+
     using Observer = Nano::Observer<>;
     using Signal_One = Nano::Signal<void(const char*)>;
     using Signal_Two = Nano::Signal<void(const char*, std::size_t)>;
 
-    // TODO Add Policy related testing
+    using Observer_TS = Nano::Observer<Nano::TS_Policy<>>;
+    using Signal_Rng_TS = Nano::Signal<void(Rng&), Nano::TS_Policy<>>;
 
-    //using Observer_TS = Nano::Observer<Nano::TS_Policy<>>;
-    //using Signal_One_TS = Nano::Signal<void(const char*), Nano::TS_Policy<>>;
-    //using Signal_Two_TS = Nano::Signal<void(const char*, std::size_t), Nano::TS_Policy<>>;
-
-    using Observer_STS = Nano::Observer<Nano::ST_Policy_Strict>;
-    using Signal_One_STS = Nano::Signal<void(const char*), Nano::ST_Policy_Strict>;
-    using Signal_Two_STS = Nano::Signal<void(const char*, std::size_t), Nano::ST_Policy_Strict>;
-
-    //using Observer_TSS = Nano::Observer<Nano::TS_Policy_Strict<>>;
-    //using Signal_One_TSS = Nano::Signal<void(const char*), Nano::TS_Policy_Strict<>>;
-    //using Signal_Two_TSS = Nano::Signal<void(const char*, std::size_t), Nano::TS_Policy_Strict<>>;
+    using Observer_TSS = Nano::Observer<Nano::TS_Policy_Strict<>>;
+    using Signal_Rng_TSS = Nano::Signal<void(Rng&), Nano::TS_Policy_Strict<>>;
 
     using Delegate_One = std::function<void(const char*)>;
     using Delegate_Two = std::function<void(const char*, std::size_t)>;
@@ -118,4 +113,16 @@ namespace Nano_Tests
         anonymous_output(__FUNCTION__, sl, ln);
     }
 
+    //--------------------------------------------------------------------------
+
+    template <typename T = Observer_TS>
+    class Moo : public T
+    {
+        public:
+
+        void slot_next_random(Rng& rng)
+        {
+            volatile std::size_t a = rng(); (void)a;
+        }
+    };
 }

--- a/tests/Test_Base.hpp
+++ b/tests/Test_Base.hpp
@@ -24,6 +24,12 @@ namespace Nano_Tests
     using Signal_One = Nano::Signal<void(const char*)>;
     using Signal_Two = Nano::Signal<void(const char*, std::size_t)>;
 
+    using Observer_ST = Nano::Observer<Nano::ST_Policy>;
+    using Signal_Rng_ST = Nano::Signal<void(Rng&), Nano::ST_Policy>;
+
+    using Observer_STS = Nano::Observer<Nano::ST_Policy_Safe>;
+    using Signal_Rng_STS = Nano::Signal<void(Rng&), Nano::ST_Policy_Safe>;
+
     using Observer_TS = Nano::Observer<Nano::TS_Policy<>>;
     using Signal_Rng_TS = Nano::Signal<void(Rng&), Nano::TS_Policy<>>;
 

--- a/tests/Test_Base.hpp
+++ b/tests/Test_Base.hpp
@@ -27,8 +27,8 @@ namespace Nano_Tests
     using Observer_TS = Nano::Observer<Nano::TS_Policy<>>;
     using Signal_Rng_TS = Nano::Signal<void(Rng&), Nano::TS_Policy<>>;
 
-    using Observer_TSS = Nano::Observer<Nano::TS_Policy_Strict<>>;
-    using Signal_Rng_TSS = Nano::Signal<void(Rng&), Nano::TS_Policy_Strict<>>;
+    using Observer_TSS = Nano::Observer<Nano::TS_Policy_Safe<>>;
+    using Signal_Rng_TSS = Nano::Signal<void(Rng&), Nano::TS_Policy_Safe<>>;
 
     using Delegate_One = std::function<void(const char*)>;
     using Delegate_Two = std::function<void(const char*, std::size_t)>;

--- a/tests/Test_ST_Policy.cpp
+++ b/tests/Test_ST_Policy.cpp
@@ -1,0 +1,39 @@
+#include <list>
+
+#include "CppUnitTest.h"
+
+#include "Test_Base.hpp"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace Nano_Tests
+{
+    TEST_CLASS(Test_ST_Policy)
+    {
+        const int N = 64;
+
+        using Moo_T = Moo<Observer_ST>;
+        using Subject = Signal_Rng_ST;
+
+        TEST_METHOD(Test_Global_Signal)
+        {
+            Subject subject;
+
+            std::size_t count = 0;
+
+            Rng rng;
+
+            for (; count < N; ++count)
+            {
+                std::list<Moo_T> moo(N);
+
+                for (auto& moo_instance : moo)
+                {
+                    subject.connect<&Moo_T::slot_next_random>(moo_instance);
+                }
+                subject.fire(rng);
+            }
+            Assert::IsTrue(subject.is_empty(), L"A signal was found not empty.");
+        }
+    };
+}

--- a/tests/Test_ST_Policy_Safe.cpp
+++ b/tests/Test_ST_Policy_Safe.cpp
@@ -1,0 +1,39 @@
+#include <list>
+
+#include "CppUnitTest.h"
+
+#include "Test_Base.hpp"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace Nano_Tests
+{
+    TEST_CLASS(Test_ST_Policy_Safe)
+    {
+        const int N = 64;
+
+        using Moo_T = Moo<Observer_STS>;
+        using Subject = Signal_Rng_STS;
+
+        TEST_METHOD(Test_Global_Signal)
+        {
+            Subject subject;
+
+            std::size_t count = 0;
+
+            Rng rng;
+
+            for (; count < N; ++count)
+            {
+                std::list<Moo_T> moo(N);
+
+                for (auto& moo_instance : moo)
+                {
+                    subject.connect<&Moo_T::slot_next_random>(moo_instance);
+                }
+                subject.fire(rng);
+            }
+            Assert::IsTrue(subject.is_empty(), L"A signal was found not empty.");
+        }
+    };
+}

--- a/tests/Test_Signal_Edge_Cases.cpp
+++ b/tests/Test_Signal_Edge_Cases.cpp
@@ -129,21 +129,23 @@ namespace Nano_Tests
             mo_signal_one.fire(__FILE__);
         }
 
-        //TEST_METHOD(Test_Signal_Copy)
-        //{
-        //    {
-        //        mo_signal_one.connect<&Foo::slot_member_signature_one>(mo_foo);
+        TEST_METHOD(Test_Signal_Copy)
+        {
+            Assert::Fail(L"This is not a supported capability.");
 
-        //        auto copy = Signal_One(mo_signal_one);
+            //{
+            //    mo_signal_one.connect<&Foo::slot_member_signature_one>(mo_foo);
 
-        //        Assert::IsFalse(copy.is_empty(), L"Copy did not copy a slot.");
+            //    auto copy = Signal_One(mo_signal_one);
 
-        //        mo_signal_one.disconnect<&Foo::slot_member_signature_one>(mo_foo);
+            //    Assert::IsFalse(copy.is_empty(), L"Copy did not copy a slot.");
 
-        //        Assert::IsFalse(copy.is_empty(), L"Copy had a slot disconnected.");
-        //        Assert::IsFalse(mo_foo.is_empty(), L"Copy no longer has an observer.");
-        //    }
-        //    Assert::IsTrue(mo_foo.is_empty(), L"Copy did not disconnect from Observer.");
-        //}
+            //    mo_signal_one.disconnect<&Foo::slot_member_signature_one>(mo_foo);
+
+            //    Assert::IsFalse(copy.is_empty(), L"Copy had a slot disconnected.");
+            //    Assert::IsFalse(mo_foo.is_empty(), L"Copy no longer has an observer.");
+            //}
+            //Assert::IsTrue(mo_foo.is_empty(), L"Copy did not disconnect from Observer.");
+        }
     };
 }

--- a/tests/Test_Signal_Edge_Cases.cpp
+++ b/tests/Test_Signal_Edge_Cases.cpp
@@ -129,21 +129,21 @@ namespace Nano_Tests
             mo_signal_one.fire(__FILE__);
         }
 
-        TEST_METHOD(Test_Signal_Copy)
-        {
-            {
-                mo_signal_one.connect<&Foo::slot_member_signature_one>(mo_foo);
+        //TEST_METHOD(Test_Signal_Copy)
+        //{
+        //    {
+        //        mo_signal_one.connect<&Foo::slot_member_signature_one>(mo_foo);
 
-                auto copy = Signal_One(mo_signal_one);
+        //        auto copy = Signal_One(mo_signal_one);
 
-                Assert::IsFalse(copy.is_empty(), L"Copy did not copy a slot.");
+        //        Assert::IsFalse(copy.is_empty(), L"Copy did not copy a slot.");
 
-                mo_signal_one.disconnect<&Foo::slot_member_signature_one>(mo_foo);
+        //        mo_signal_one.disconnect<&Foo::slot_member_signature_one>(mo_foo);
 
-                Assert::IsFalse(copy.is_empty(), L"Copy had a slot disconnected.");
-                Assert::IsFalse(mo_foo.is_empty(), L"Copy no longer has an observer.");
-            }
-            Assert::IsTrue(mo_foo.is_empty(), L"Copy did not disconnect from Observer.");
-        }
+        //        Assert::IsFalse(copy.is_empty(), L"Copy had a slot disconnected.");
+        //        Assert::IsFalse(mo_foo.is_empty(), L"Copy no longer has an observer.");
+        //    }
+        //    Assert::IsTrue(mo_foo.is_empty(), L"Copy did not disconnect from Observer.");
+        //}
     };
 }

--- a/tests/Test_Signal_Edge_Cases.cpp
+++ b/tests/Test_Signal_Edge_Cases.cpp
@@ -128,5 +128,22 @@ namespace Nano_Tests
             };
             mo_signal_one.fire(__FILE__);
         }
+
+        TEST_METHOD(Test_Signal_Copy)
+        {
+            {
+                mo_signal_one.connect<&Foo::slot_member_signature_one>(mo_foo);
+
+                auto copy = Signal_One(mo_signal_one);
+
+                Assert::IsFalse(copy.is_empty(), L"Copy did not copy a slot.");
+
+                mo_signal_one.disconnect<&Foo::slot_member_signature_one>(mo_foo);
+
+                Assert::IsFalse(copy.is_empty(), L"Copy had a slot disconnected.");
+                Assert::IsFalse(mo_foo.is_empty(), L"Copy no longer has an observer.");
+            }
+            Assert::IsTrue(mo_foo.is_empty(), L"Copy did not disconnect from Observer.");
+        }
     };
 }

--- a/tests/Test_Signal_Edge_Cases.cpp
+++ b/tests/Test_Signal_Edge_Cases.cpp
@@ -15,6 +15,8 @@ namespace Nano_Tests
         Signal_One mo_signal_one;
         Signal_Two mo_signal_two;
 
+        Signal_One_STS mo_signal_one_sts;
+
         Foo mo_foo;
         Bar mo_bar;
 
@@ -114,24 +116,19 @@ namespace Nano_Tests
         {
             Delegate_One fo1;
 
-            mo_signal_one.connect(fo1);
-            mo_signal_one.connect<&Foo::slot_member_signature_one>(mo_foo);
-            mo_signal_one.connect<&Foo::slot_const_member_signature_one>(mo_foo);
-            mo_signal_one.connect<Foo, &Foo::slot_overloaded_member>(mo_foo);
-            mo_signal_one.connect<&Foo::slot_static_member_function>();
-            mo_signal_one.connect<Foo, &Foo::slot_virtual_member_function>(mo_foo);
-            mo_signal_one.connect<Bar, &Bar::slot_virtual_member_function>(mo_bar);
+            auto limit = 0;
+
+            mo_signal_one_sts.connect(fo1);
 
             fo1 = [&](const char* sl)
             {
-                // TODO Prevent this infinite loop
-                // This would require a custom data structure for Observer
-                // in order to realize a no-cost solution to this problem
-
-                //mo_signal_one.fire(__FILE__);
+                if (++limit > 2)
+                {
+                    Assert::Fail(L"This is not a supported use case.");
+                }
+                mo_signal_one_sts.fire(__FILE__);
             };
-
-            mo_signal_one.fire(__FILE__);
+            mo_signal_one_sts.fire(__FILE__);
         }
     };
 }

--- a/tests/Test_Signal_Edge_Cases.cpp
+++ b/tests/Test_Signal_Edge_Cases.cpp
@@ -15,8 +15,6 @@ namespace Nano_Tests
         Signal_One mo_signal_one;
         Signal_Two mo_signal_two;
 
-        Signal_One_STS mo_signal_one_sts;
-
         Foo mo_foo;
         Bar mo_bar;
 
@@ -118,7 +116,7 @@ namespace Nano_Tests
 
             auto limit = 0;
 
-            mo_signal_one_sts.connect(fo1);
+            mo_signal_one.connect(fo1);
 
             fo1 = [&](const char* sl)
             {
@@ -126,9 +124,9 @@ namespace Nano_Tests
                 {
                     Assert::Fail(L"This is not a supported use case.");
                 }
-                mo_signal_one_sts.fire(__FILE__);
+                mo_signal_one.fire(__FILE__);
             };
-            mo_signal_one_sts.fire(__FILE__);
+            mo_signal_one.fire(__FILE__);
         }
     };
 }

--- a/tests/Test_TS_Policy.cpp
+++ b/tests/Test_TS_Policy.cpp
@@ -1,0 +1,48 @@
+#include <future>
+
+#include "CppUnitTest.h"
+
+#include "Test_Base.hpp"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace Nano_Tests
+{
+    TEST_CLASS(Test_TS_Policy)
+    {
+        using Moo_TS = Moo<Observer_TS>;
+
+        TEST_METHOD(Test_Shared_Signal)
+        {
+            Signal_Rng_TS subject;
+
+            auto context = [&]()
+            {
+                std::size_t count = 0;
+
+                Rng rng;
+
+                for (; count < 32; ++count)
+                {
+                    std::vector<Moo_TS> moo(32);
+
+                    for (auto& moo_instance : moo)
+                    {
+                        subject.connect<&Moo_TS::slot_next_random>(moo_instance);
+                    }
+                    subject.fire(rng);
+                }
+            };
+            std::vector<std::future<void>> future_results;
+            for (std::size_t i = std::thread::hardware_concurrency(); i > 0; --i)
+            {
+                future_results.emplace_back(std::async(std::launch::async, context));
+            }
+            for (auto& future_result : future_results)
+            {
+                future_result.get();
+            }
+            Assert::IsTrue(subject.is_empty(), L"A signal was found not empty.");
+        }
+    };
+}

--- a/tests/Test_TS_Policy.cpp
+++ b/tests/Test_TS_Policy.cpp
@@ -11,11 +11,14 @@ namespace Nano_Tests
 {
     TEST_CLASS(Test_TS_Policy)
     {
-        using Moo_TS = Moo<Observer_TS>;
+        const int N = 64;
+
+        using Moo_T = Moo<Observer_TS>;
+        using Subject = Signal_Rng_TS;
 
         TEST_METHOD(Test_Shared_Signal)
         {
-            Signal_Rng_TS subject;
+            Subject subject;
 
             auto context = [&]()
             {
@@ -23,13 +26,13 @@ namespace Nano_Tests
 
                 Rng rng;
 
-                for (; count < 32; ++count)
+                for (; count < N; ++count)
                 {
-                    std::list<Moo_TS> moo(32);
+                    std::list<Moo_T> moo(N);
 
                     for (auto& moo_instance : moo)
                     {
-                        subject.connect<&Moo_TS::slot_next_random>(moo_instance);
+                        subject.connect<&Moo_T::slot_next_random>(moo_instance);
                     }
                     subject.fire(rng);
                 }

--- a/tests/Test_TS_Policy.cpp
+++ b/tests/Test_TS_Policy.cpp
@@ -1,4 +1,5 @@
 #include <future>
+#include <list>
 
 #include "CppUnitTest.h"
 
@@ -24,7 +25,7 @@ namespace Nano_Tests
 
                 for (; count < 32; ++count)
                 {
-                    std::vector<Moo_TS> moo(32);
+                    std::list<Moo_TS> moo(32);
 
                     for (auto& moo_instance : moo)
                     {

--- a/tests/Test_TS_Policy_Safe.cpp
+++ b/tests/Test_TS_Policy_Safe.cpp
@@ -11,11 +11,14 @@ namespace Nano_Tests
 {
     TEST_CLASS(Test_TS_Policy_Safe)
     {
-        using Moo_TSS = Moo<Observer_TSS>;
+        const int N = 64;
+
+        using Moo_T = Moo<Observer_TSS>;
+        using Subject = Signal_Rng_TSS;
 
         TEST_METHOD(Test_Shared_Signal)
         {
-            Signal_Rng_TSS subject;
+            Subject subject;
 
             auto context = [&]()
             {
@@ -23,13 +26,13 @@ namespace Nano_Tests
 
                 Rng rng;
 
-                for (; count < 32; ++count)
+                for (; count < N; ++count)
                 {
-                    std::list<Moo_TSS> moo(32);
+                    std::list<Moo_T> moo(N);
 
                     for (auto& moo_instance : moo)
                     {
-                        subject.connect<&Moo_TSS::slot_next_random>(moo_instance);
+                        subject.connect<&Moo_T::slot_next_random>(moo_instance);
                     }
                     subject.fire(rng);
                 }

--- a/tests/Test_TS_Policy_Safe.cpp
+++ b/tests/Test_TS_Policy_Safe.cpp
@@ -9,7 +9,7 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace Nano_Tests
 {
-    TEST_CLASS(Test_TS_Policy_Strict)
+    TEST_CLASS(Test_TS_Policy_Safe)
     {
         using Moo_TSS = Moo<Observer_TSS>;
 

--- a/tests/Test_TS_Policy_Safe.cpp
+++ b/tests/Test_TS_Policy_Safe.cpp
@@ -11,7 +11,8 @@ namespace Nano_Tests
 {
     TEST_CLASS(Test_TS_Policy_Safe)
     {
-        const int N = 64;
+        const int N = 64; // 4 seconds
+        //const int N = 256; // 4 minutes
 
         using Moo_T = Moo<Observer_TSS>;
         using Subject = Signal_Rng_TSS;

--- a/tests/Test_TS_Policy_Strict.cpp
+++ b/tests/Test_TS_Policy_Strict.cpp
@@ -1,4 +1,5 @@
 #include <future>
+#include <list>
 
 #include "CppUnitTest.h"
 
@@ -24,7 +25,7 @@ namespace Nano_Tests
 
                 for (; count < 32; ++count)
                 {
-                    std::vector<Moo_TSS> moo(32);
+                    std::list<Moo_TSS> moo(32);
 
                     for (auto& moo_instance : moo)
                     {

--- a/tests/Test_TS_Policy_Strict.cpp
+++ b/tests/Test_TS_Policy_Strict.cpp
@@ -1,0 +1,48 @@
+#include <future>
+
+#include "CppUnitTest.h"
+
+#include "Test_Base.hpp"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace Nano_Tests
+{
+    TEST_CLASS(Test_TS_Policy_Strict)
+    {
+        using Moo_TSS = Moo<Observer_TSS>;
+
+        TEST_METHOD(Test_Shared_Signal)
+        {
+            Signal_Rng_TSS subject;
+
+            auto context = [&]()
+            {
+                std::size_t count = 0;
+
+                Rng rng;
+
+                for (; count < 32; ++count)
+                {
+                    std::vector<Moo_TSS> moo(32);
+
+                    for (auto& moo_instance : moo)
+                    {
+                        subject.connect<&Moo_TSS::slot_next_random>(moo_instance);
+                    }
+                    subject.fire(rng);
+                }
+            };
+            std::vector<std::future<void>> future_results;
+            for (std::size_t i = std::thread::hardware_concurrency(); i > 0; --i)
+            {
+                future_results.emplace_back(std::async(std::launch::async, context));
+            }
+            for (auto& future_result : future_results)
+            {
+                future_result.get();
+            }
+            Assert::IsTrue(subject.is_empty(), L"A signal was found not empty.");
+        }
+    };
+}

--- a/vs/nano-signal-slot.vcxproj
+++ b/vs/nano-signal-slot.vcxproj
@@ -34,32 +34,32 @@
     <ProjectGuid>{6BF0958D-0E5D-4DEB-B94C-AB7C549CF025}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Nano</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -132,7 +132,6 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -182,7 +181,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vs/nano-signal-slot.vcxproj
+++ b/vs/nano-signal-slot.vcxproj
@@ -111,6 +111,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -131,6 +132,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -155,6 +157,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -179,6 +182,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vs/tests/tests.vcxproj
+++ b/vs/tests/tests.vcxproj
@@ -194,6 +194,8 @@
     <ClCompile Include="..\..\tests\Test_Signal_Disconnect.cpp" />
     <ClCompile Include="..\..\tests\Test_Signal_Edge_Cases.cpp" />
     <ClCompile Include="..\..\tests\Test_Signal_Fire.cpp" />
+    <ClCompile Include="..\..\tests\Test_TS_Policy.cpp" />
+    <ClCompile Include="..\..\tests\Test_TS_Policy_Strict.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\tests\Test_Base.hpp" />

--- a/vs/tests/tests.vcxproj
+++ b/vs/tests/tests.vcxproj
@@ -107,6 +107,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -129,6 +130,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -155,6 +157,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -181,6 +184,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -194,6 +198,8 @@
     <ClCompile Include="..\..\tests\Test_Signal_Disconnect.cpp" />
     <ClCompile Include="..\..\tests\Test_Signal_Edge_Cases.cpp" />
     <ClCompile Include="..\..\tests\Test_Signal_Fire.cpp" />
+    <ClCompile Include="..\..\tests\Test_ST_Policy.cpp" />
+    <ClCompile Include="..\..\tests\Test_ST_Policy_Safe.cpp" />
     <ClCompile Include="..\..\tests\Test_TS_Policy.cpp" />
     <ClCompile Include="..\..\tests\Test_TS_Policy_Safe.cpp" />
   </ItemGroup>

--- a/vs/tests/tests.vcxproj
+++ b/vs/tests/tests.vcxproj
@@ -23,21 +23,21 @@
     <ProjectGuid>{DA4DFE8B-33F8-4FB2-901E-560393E8F0A0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Nano_Tests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
@@ -45,14 +45,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
@@ -107,7 +107,6 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -184,7 +183,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/vs/tests/tests.vcxproj
+++ b/vs/tests/tests.vcxproj
@@ -195,7 +195,7 @@
     <ClCompile Include="..\..\tests\Test_Signal_Edge_Cases.cpp" />
     <ClCompile Include="..\..\tests\Test_Signal_Fire.cpp" />
     <ClCompile Include="..\..\tests\Test_TS_Policy.cpp" />
-    <ClCompile Include="..\..\tests\Test_TS_Policy_Strict.cpp" />
+    <ClCompile Include="..\..\tests\Test_TS_Policy_Safe.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\tests\Test_Base.hpp" />

--- a/vs/tests/tests.vcxproj.filters
+++ b/vs/tests/tests.vcxproj.filters
@@ -37,6 +37,12 @@
     <ClCompile Include="..\..\tests\Test_Observer_Destruction.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\tests\Test_TS_Policy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\tests\Test_TS_Policy_Strict.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\tests\README.md">

--- a/vs/tests/tests.vcxproj.filters
+++ b/vs/tests/tests.vcxproj.filters
@@ -43,6 +43,12 @@
     <ClCompile Include="..\..\tests\Test_TS_Policy_Safe.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\tests\Test_ST_Policy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\tests\Test_ST_Policy_Safe.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\tests\README.md">

--- a/vs/tests/tests.vcxproj.filters
+++ b/vs/tests/tests.vcxproj.filters
@@ -40,7 +40,7 @@
     <ClCompile Include="..\..\tests\Test_TS_Policy.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\tests\Test_TS_Policy_Strict.cpp">
+    <ClCompile Include="..\..\tests\Test_TS_Policy_Safe.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Closes #22, closes #15. Fixes warnings and error in latest vs 2019. The policy system has been rewritten coinciding with the new architecture of the Observer class. Spinlock is now a relaxed test and test and set.