### PR TITLE
Explicitly default/delete copy and move constructors for signal and observer types

### DIFF
--- a/nano_mutex.hpp
+++ b/nano_mutex.hpp
@@ -34,12 +34,20 @@ class Spin_Mutex
     Spin_Mutex() noexcept = default;
     virtual ~Spin_Mutex() noexcept = default;
 
-    // Not copyable or movable due to owning an atomic_bool
-    Spin_Mutex(Spin_Mutex const&) noexcept = delete;
-    Spin_Mutex& operator= (Spin_Mutex const&) noexcept = delete;
+    // Because all we own is a trivially-copyable atomic_bool, we can manually move/copy
+    Spin_Mutex(Spin_Mutex const& other) noexcept : locked{other.locked.load()} {}
+    Spin_Mutex& operator= (Spin_Mutex const& other) noexcept
+    {
+        locked = other.locked.load();
+        return *this;
+    }
 
-    Spin_Mutex(Spin_Mutex&&) noexcept = delete;
-    Spin_Mutex& operator= (Spin_Mutex&&) noexcept = delete;
+    Spin_Mutex(Spin_Mutex&& other) noexcept : locked{other.locked.load()} {}
+    Spin_Mutex& operator= (Spin_Mutex&& other) noexcept
+    {
+        locked = other.locked.load();
+        return *this;
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -142,11 +150,11 @@ class TS_Policy
     TS_Policy() noexcept = default;
     ~TS_Policy() noexcept = default;
 
-    TS_Policy(TS_Policy const&) noexcept = delete;
-    TS_Policy& operator= (TS_Policy const&) noexcept = delete;
+    TS_Policy(TS_Policy const&) noexcept = default;
+    TS_Policy& operator= (TS_Policy const&) noexcept = default;
 
-    TS_Policy(TS_Policy&&) noexcept = delete;
-    TS_Policy& operator= (TS_Policy&&) noexcept = delete;
+    TS_Policy(TS_Policy&&) noexcept = default;
+    TS_Policy& operator= (TS_Policy&&) noexcept = default;
 
     using Weak_Ptr = TS_Policy*;
 
@@ -280,11 +288,11 @@ class TS_Policy_Safe
     TS_Policy_Safe() noexcept = default;
     ~TS_Policy_Safe() noexcept = default;
 
-    TS_Policy_Safe(TS_Policy_Safe const&) noexcept = delete;
-    TS_Policy_Safe& operator= (TS_Policy_Safe const&) noexcept = delete;
+    TS_Policy_Safe(TS_Policy_Safe const&) noexcept = default;
+    TS_Policy_Safe& operator= (TS_Policy_Safe const&) noexcept = default;
 
-    TS_Policy_Safe(TS_Policy_Safe&&) noexcept = delete;
-    TS_Policy_Safe& operator= (TS_Policy_Safe&&) noexcept = delete;
+    TS_Policy_Safe(TS_Policy_Safe&&) noexcept = default;
+    TS_Policy_Safe& operator= (TS_Policy_Safe&&) noexcept = default;
 
     using Weak_Ptr = std::weak_ptr<TS_Policy_Safe>;
 

--- a/nano_mutex.hpp
+++ b/nano_mutex.hpp
@@ -8,7 +8,7 @@
 namespace Nano
 {
 
-class Spin_Mutex
+class Spin_Mutex final
 {
     std::atomic_bool locked = { false };
 
@@ -32,7 +32,7 @@ class Spin_Mutex
     }
 
     Spin_Mutex() noexcept = default;
-    virtual ~Spin_Mutex() noexcept = default;
+    ~Spin_Mutex() noexcept = default;
 
     // Because all we own is a trivially-copyable atomic_bool, we can manually move/copy
     Spin_Mutex(Spin_Mutex const& other) noexcept : locked{other.locked.load()} {}

--- a/nano_mutex.hpp
+++ b/nano_mutex.hpp
@@ -32,8 +32,14 @@ class Spin_Mutex
     }
 
     Spin_Mutex() noexcept = default;
-    Spin_Mutex(Spin_Mutex const&) = delete;
-    Spin_Mutex& operator= (Spin_Mutex const&) = delete;
+    virtual ~Spin_Mutex() noexcept = default;
+
+    // Not copyable or movable due to owning an atomic_bool
+    Spin_Mutex(Spin_Mutex const&) noexcept = delete;
+    Spin_Mutex& operator= (Spin_Mutex const&) noexcept = delete;
+
+    Spin_Mutex(Spin_Mutex&&) noexcept = delete;
+    Spin_Mutex& operator= (Spin_Mutex&&) noexcept = delete;
 };
 
 //------------------------------------------------------------------------------
@@ -58,6 +64,15 @@ class ST_Policy
     }
 
     protected:
+
+    ST_Policy() noexcept = default;
+    ~ST_Policy() noexcept = default;
+
+    ST_Policy(const ST_Policy&) noexcept = default;
+    ST_Policy& operator=(const ST_Policy&) noexcept = default;
+
+    ST_Policy(ST_Policy&&) noexcept = default;
+    ST_Policy& operator=(ST_Policy&&) noexcept = default;
 
     using Weak_Ptr = ST_Policy*;
 
@@ -124,6 +139,15 @@ class TS_Policy
 
     protected:
 
+    TS_Policy() noexcept = default;
+    ~TS_Policy() noexcept = default;
+
+    TS_Policy(TS_Policy const&) noexcept = delete;
+    TS_Policy& operator= (TS_Policy const&) noexcept = delete;
+
+    TS_Policy(TS_Policy&&) noexcept = delete;
+    TS_Policy& operator= (TS_Policy&&) noexcept = delete;
+
     using Weak_Ptr = TS_Policy*;
 
     constexpr auto weak_ptr()
@@ -174,6 +198,15 @@ class ST_Policy_Safe
     }
 
     protected:
+
+    ST_Policy_Safe() noexcept = default;
+    ~ST_Policy_Safe() noexcept = default;
+
+    ST_Policy_Safe(ST_Policy_Safe const&) noexcept = default;
+    ST_Policy_Safe& operator= (ST_Policy_Safe const&) noexcept = default;
+
+    ST_Policy_Safe(ST_Policy_Safe&&) noexcept = default;
+    ST_Policy_Safe& operator= (ST_Policy_Safe&&) noexcept = default;
 
     using Weak_Ptr = ST_Policy_Safe*;
 
@@ -245,6 +278,13 @@ class TS_Policy_Safe
     protected:
 
     TS_Policy_Safe() noexcept = default;
+    ~TS_Policy_Safe() noexcept = default;
+
+    TS_Policy_Safe(TS_Policy_Safe const&) noexcept = delete;
+    TS_Policy_Safe& operator= (TS_Policy_Safe const&) noexcept = delete;
+
+    TS_Policy_Safe(TS_Policy_Safe&&) noexcept = delete;
+    TS_Policy_Safe& operator= (TS_Policy_Safe&&) noexcept = delete;
 
     using Weak_Ptr = std::weak_ptr<TS_Policy_Safe>;
 

--- a/nano_observer.hpp
+++ b/nano_observer.hpp
@@ -42,7 +42,6 @@ class Observer : private MT_Policy
     };
 
     std::vector<Connection> connections;
-    bool movedFrom = false;
 
     //--------------------------------------------------------------------------
 
@@ -159,8 +158,7 @@ class Observer : private MT_Policy
     {
         MT_Policy::before_disconnect_all();
 
-        if (!movedFrom)
-            disconnect_all();
+        disconnect_all();
     }
 
     Observer() noexcept = default;
@@ -173,13 +171,11 @@ class Observer : private MT_Policy
     Observer(Observer&& other) noexcept
     {
         move_connections_from(&other);
-        other.movedFrom = true;
     }
 
     Observer& operator=(Observer&& other) noexcept
     {
         move_connections_from(&other);
-        other.movedFrom = true;
         return *this;
     }
 };

--- a/nano_observer.hpp
+++ b/nano_observer.hpp
@@ -133,8 +133,13 @@ class Observer : private MT_Policy
     }
 
     Observer() noexcept = default;
-    Observer(Observer const&) = delete;
-    Observer& operator= (Observer const&) = delete;
+
+    // Observer may be movable depending on policy, but should never be copied
+    Observer(Observer const&) noexcept = delete;
+    Observer& operator= (Observer const&) noexcept = delete;
+
+    Observer(Observer&&) noexcept = default;
+    Observer& operator=(Observer&&) noexcept = default;
 };
 
 } // namespace Nano ------------------------------------------------------------

--- a/nano_signal_slot.hpp
+++ b/nano_signal_slot.hpp
@@ -158,11 +158,11 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
             (std::forward<Accumulate>(accumulate), std::forward<Uref>(args)...);
     }
 
-    Signal() = default;
-    ~Signal() = default;
+    Signal() noexcept = default;
+    ~Signal() noexcept = default;
 
-    Signal(Signal const&) = delete;
-    Signal& operator= (Signal const&) = delete;
+    Signal(Signal const&) noexcept = delete;
+    Signal& operator= (Signal const&) noexcept = delete;
 
     Signal(Signal&&) noexcept = default;
     Signal& operator=(Signal&&) noexcept = default;

--- a/nano_signal_slot.hpp
+++ b/nano_signal_slot.hpp
@@ -38,7 +38,7 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     }
 
     public:
- 
+
     //-------------------------------------------------------------------CONNECT
 
     template <typename L>
@@ -157,6 +157,15 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
         observer::template for_each_accumulate<function, Accumulate>
             (std::forward<Accumulate>(accumulate), std::forward<Uref>(args)...);
     }
+
+    Signal() = default;
+    ~Signal() = default;
+
+    Signal(Signal const&) = delete;
+    Signal& operator= (Signal const&) = delete;
+
+    Signal(Signal&&) noexcept = default;
+    Signal& operator=(Signal&&) noexcept = default;
 };
 
 } // namespace Nano ------------------------------------------------------------

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ _Built using c++17 conformance mode (/permissive-)_
 | | Test_Fire_RValue_Copy | PASS |
 | Test_ST_Policy | | |
 | | Test_Global_Signal | PASS |
-| | Test_Signal_Move | &mdash; |
+| | Test_Signal_Move | PASS |
 | | Test_Fire_Disconnect | &mdash; |
 | | Test_Fire_Disconnects | &mdash; |
 | | Test_Fire_Connects | &mdash; |
@@ -49,7 +49,7 @@ _Built using c++17 conformance mode (/permissive-)_
 | | Test_Fire_Fire | &mdash; |
 | Test_ST_Policy_Safe | | |
 | | Test_Global_Signal | PASS |
-| | Test_Signal_Move | &mdash; |
+| | Test_Signal_Move | PASS |
 | | Test_Fire_Disconnect | PASS |
 | | Test_Fire_Disconnects | PASS |
 | | Test_Fire_Connects | PASS |
@@ -57,7 +57,7 @@ _Built using c++17 conformance mode (/permissive-)_
 | | Test_Fire_Fire | PASS |
 | Test_TS_Policy | | |
 | | Test_Shared_Signal | PASS |
-| | Test_Signal_Move | &mdash; |
+| | Test_Signal_Move | PASS |
 | | Test_Fire_Disconnect | &mdash; |
 | | Test_Fire_Disconnects | &mdash; |
 | | Test_Fire_Connects | &mdash; |
@@ -65,7 +65,7 @@ _Built using c++17 conformance mode (/permissive-)_
 | | Test_Fire_Fire | &mdash; |
 | Test_TS_Policy_Safe | | |
 | | Test_Shared_Signal | PASS |
-| | Test_Signal_Move | &mdash; |
+| | Test_Signal_Move | PASS |
 | | Test_Fire_Disconnect | PASS |
 | | Test_Fire_Disconnects | PASS |
 | | Test_Fire_Connects | PASS |

--- a/tests/Test_ST_Policy.cpp
+++ b/tests/Test_ST_Policy.cpp
@@ -38,27 +38,27 @@ namespace Nano_Tests
 
         //----------------------------------------------------------------------
 
-        //TEST_METHOD(Test_Signal_Move)
-        //{
-        //    Moo_T foo;
+        TEST_METHOD(Test_Signal_Move)
+        {
+            Moo_T foo;
 
-        //    Subject* signal_one = new Subject();
+            Subject* signal_one = new Subject();
 
-        //    signal_one->connect<&Moo_T::slot_next_random>(foo);
+            signal_one->connect<&Moo_T::slot_next_random>(foo);
 
-        //    {
-        //        Subject signal_two = std::move(*signal_one);
+            {
+                Subject signal_two = std::move(*signal_one);
 
-        //        Assert::IsTrue(signal_one->is_empty(), L"Signal failed to sink.");
+                Assert::IsTrue(signal_one->is_empty(), L"Signal failed to sink.");
 
-        //        delete signal_one;
+                delete signal_one;
 
-        //        signal_two.fire(Rng());
+                signal_two.fire(Rng());
 
-        //        foo.disconnect_all();
-        //    }
+                foo.disconnect_all();
+            }
 
-        //    Assert::IsTrue(foo.is_empty(), L"Signal failed to sink.");
-        //}
+            Assert::IsTrue(foo.is_empty(), L"Signal failed to sink.");
+        }
     };
 }

--- a/tests/Test_ST_Policy_Safe.cpp
+++ b/tests/Test_ST_Policy_Safe.cpp
@@ -38,28 +38,28 @@ namespace Nano_Tests
 
         //----------------------------------------------------------------------
 
-        //TEST_METHOD(Test_Signal_Move)
-        //{
-        //    Moo_T foo;
+        TEST_METHOD(Test_Signal_Move)
+        {
+            Moo_T foo;
 
-        //    Subject* signal_one = new Subject();
+            Subject* signal_one = new Subject();
 
-        //    signal_one->connect<&Moo_T::slot_next_random>(foo);
+            signal_one->connect<&Moo_T::slot_next_random>(foo);
 
-        //    {
-        //        Subject signal_two = std::move(*signal_one);
+            {
+                Subject signal_two = std::move(*signal_one);
 
-        //        Assert::IsTrue(signal_one->is_empty(), L"Signal failed to sink.");
+                Assert::IsTrue(signal_one->is_empty(), L"Signal failed to sink.");
 
-        //        delete signal_one;
+                delete signal_one;
 
-        //        signal_two.fire(Rng());
+                signal_two.fire(Rng());
 
-        //        foo.disconnect_all();
-        //    }
+                foo.disconnect_all();
+            }
 
-        //    Assert::IsTrue(foo.is_empty(), L"Signal failed to sink.");
-        //}
+            Assert::IsTrue(foo.is_empty(), L"Signal failed to sink.");
+        }
 
         //----------------------------------------------------------------------
 

--- a/tests/Test_TS_Policy.cpp
+++ b/tests/Test_TS_Policy.cpp
@@ -51,27 +51,27 @@ namespace Nano_Tests
 
         //----------------------------------------------------------------------
 
-        //TEST_METHOD(Test_Signal_Move)
-        //{
-        //    Moo_T foo;
+        TEST_METHOD(Test_Signal_Move)
+        {
+            Moo_T foo;
 
-        //    Subject* signal_one = new Subject();
+            Subject* signal_one = new Subject();
 
-        //    signal_one->connect<&Moo_T::slot_next_random>(foo);
+            signal_one->connect<&Moo_T::slot_next_random>(foo);
 
-        //    {
-        //        Subject signal_two = std::move(*signal_one);
+            {
+                Subject signal_two = std::move(*signal_one);
 
-        //        Assert::IsTrue(signal_one->is_empty(), L"Signal failed to sink.");
+                Assert::IsTrue(signal_one->is_empty(), L"Signal failed to sink.");
 
-        //        delete signal_one;
+                delete signal_one;
 
-        //        signal_two.fire(Rng());
+                signal_two.fire(Rng());
 
-        //        foo.disconnect_all();
-        //    }
+                foo.disconnect_all();
+            }
 
-        //    Assert::IsTrue(foo.is_empty(), L"Signal failed to sink.");
-        //}
+            Assert::IsTrue(foo.is_empty(), L"Signal failed to sink.");
+        }
     };
 }

--- a/tests/Test_TS_Policy_Safe.cpp
+++ b/tests/Test_TS_Policy_Safe.cpp
@@ -52,28 +52,28 @@ namespace Nano_Tests
 
         //----------------------------------------------------------------------
 
-        //TEST_METHOD(Test_Signal_Move)
-        //{
-        //    Moo_T foo;
+        TEST_METHOD(Test_Signal_Move)
+        {
+            Moo_T foo;
 
-        //    Subject* signal_one = new Subject();
+            Subject* signal_one = new Subject();
 
-        //    signal_one->connect<&Moo_T::slot_next_random>(foo);
+            signal_one->connect<&Moo_T::slot_next_random>(foo);
 
-        //    {
-        //        Subject signal_two = std::move(*signal_one);
+            {
+                Subject signal_two = std::move(*signal_one);
 
-        //        Assert::IsTrue(signal_one->is_empty(), L"Signal failed to sink.");
+                Assert::IsTrue(signal_one->is_empty(), L"Signal failed to sink.");
 
-        //        delete signal_one;
+                delete signal_one;
 
-        //        signal_two.fire(Rng());
+                signal_two.fire(Rng());
 
-        //        foo.disconnect_all();
-        //    }
+                foo.disconnect_all();
+            }
 
-        //    Assert::IsTrue(foo.is_empty(), L"Signal failed to sink.");
-        //}
+            Assert::IsTrue(foo.is_empty(), L"Signal failed to sink.");
+        }
 
         //----------------------------------------------------------------------
 


### PR DESCRIPTION
This applies the Rule of Five to signal and observer types, explicitly specifying their default destructors, copiers, and movers.

Motivation:

I had a class derived from `Observer<>` which I wanted to be owned by movable objects.   
Objects of that class could not be moved, and were not even `MoveInsertable` for e.g. `vector::emplace_back`.   
This turned out to be because the move constructor on `Observer` was not explicitly defined, and adding a default to `Observer` allowed my type to be moved.

While I was at it, I also went ahead and explicitly defined defaulted/deleted move/copy operators for the policy classes.   
- ~~`Spin_Mutex` is not copyable or movable due to containing an `atomic_bool`, therefore neither are the `TS` policies.~~
- ~~The `ST` policies are themselves both copyable and movable, though copying ends up not mattering since `Observer` shouldn't be copyable anyway.~~

**Update**
`Spin_Mutex` contains only an `atomic_bool`, so it can be trivially lock-free copied and moved by simply copying the bool value.  
This means that all policies, `ST` and `TS` alike, are both movable and copyable.  While this opens up the possibility of a non-deleted copy for `Observer`, I'm keeping it non-copyable because that seems like a bigger change of behavior than is in scope here.

TL;DR - given this class 
```cpp
class TestObserver : public Nano::Observer<>
{
public:
    TestObserver() = default;
    ~TestObserver() = default;

    TestObserver(const TestObserver&) = default;
    TestObserver& operator=(const TestObserver&) = default;

    TestObserver(TestObserver&&) = default;
    TestObserver& operator=(TestObserver&&) = default;
};
```
this change makes it so that a `TestObserver` can be moved.