### PR TITLE
Fix compilation issues under Clang 19.1.5

### DIFF
--- a/nano_signal_slot.hpp
+++ b/nano_signal_slot.hpp
@@ -53,7 +53,7 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     template <typename L>
     void connect(L* instance)
     {
-        observer::insert(function::template bind(instance), this);
+        observer::insert(function::template bind<>(instance), this);
     }
     template <typename L>
     void connect(L& instance)
@@ -105,7 +105,7 @@ class Signal<RT(Args...), MT_Policy> final : public Observer<MT_Policy>
     template <typename L>
     void disconnect(L* instance)
     {
-        observer::remove(function::template bind(instance));
+        observer::remove(function::template bind<>(instance));
     }
     template <typename L>
     void disconnect(L& instance)


### PR DESCRIPTION
With newer versions of Clang template arguments are required when using the template keyword otherwise you'll get the following compilation error :

`error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]`

This appears to be mandated by the [language spec](https://github.com/llvm/llvm-project/pull/80801), so it wouldn't surprise me if newer versions of GCC or MSVC start failing with a similar issue at some point.